### PR TITLE
re-order when stairs are defined

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -38,6 +38,15 @@ stairs.register_stair_and_slab(
 	default.node_sound_stone_defaults()
 )
 
+jonez.chisel.register_chiselable("jonez:marble_brick", "jonez:marble_brick", "raw" )
+minetest.register_node("jonez:marble_brick", {
+	description = S("Ancient Marble Brick"),
+	tiles = {"jonez_marble_brick.png"},
+	is_ground_content = false,
+	groups = {cracky=3},
+	sounds = default.node_sound_stone_defaults(),
+})
+
 jonez.chisel.register_chiselable_stair_and_slab("marble_brick", "marble_brick", "raw" )
 stairs.register_stair_and_slab(
 	"marble_brick",
@@ -48,15 +57,6 @@ stairs.register_stair_and_slab(
 	S("Ancient Marble Brick Slab"),
 	default.node_sound_stone_defaults()
 )
-
-jonez.chisel.register_chiselable("jonez:marble_brick", "jonez:marble_brick", "raw" )
-minetest.register_node("jonez:marble_brick", {
-	description = S("Ancient Marble Brick"),
-	tiles = {"jonez_marble_brick.png"},
-	is_ground_content = false,
-	groups = {cracky=3},
-	sounds = default.node_sound_stone_defaults(),
-})
 
 jonez.chisel.register_chiselable("jonez:marble_brick_polished", "jonez:marble_brick", "polished" )
 minetest.register_node("jonez:marble_brick_polished", {

--- a/mod.conf
+++ b/mod.conf
@@ -1,2 +1,2 @@
 name = jonez
-depends = stairs, xpanes
+depends = default, dye, stairs, xpanes


### PR DESCRIPTION
because of some work i am engaged in for moreblocks (https://github.com/minetest-mods/moreblocks/pull/191), which includes overriding the stairs mod from minetest_game, recipe nodes need to be defined before stairs are. no code actually needs to be changed, but the order of the registrations does. 

i also added a couple missing dependencies that i noticed. 